### PR TITLE
on the original BrainPad, only allocate vram memory when the display …

### DIFF
--- a/GHIElectronics.TinyCLR.BrainPad/Display.cs
+++ b/GHIElectronics.TinyCLR.BrainPad/Display.cs
@@ -79,7 +79,7 @@ namespace GHIElectronics.TinyCLR.BrainPad {
             None
         }
 
-        private I2cDevice i2cDevice = I2cDevice.FromId(Board.BoardType == BoardType.BP2 ? FEZChip.I2cBus.I2c1 : G30.I2cBus.I2c1, new I2cConnectionSettings(0x3C) { BusSpeed = I2cBusSpeed.FastMode });
+        private I2cDevice i2cDevice = I2cDevice.FromId(Board.BoardType == BoardType.BP2 ? FEZCLR.I2cBus.I2c1 : G30.I2cBus.I2c1, new I2cConnectionSettings(0x3C) { BusSpeed = I2cBusSpeed.FastMode });
 
         public Picture CreatePicture(int width, int height, byte[] data) => this.CreateScaledPicture(width, height, data, 1);
         public Picture CreateScaledPicture(int width, int height, byte[] data, int scale) => data != null ? new Picture(width, height, data, scale) : throw new Exception("Incorrect picture data size");


### PR DESCRIPTION
…is used.

