### PR TITLE
Fixed ghi-electronics/TinyCLR-Ports#515.

### DIFF
--- a/GHIElectronics.TinyCLR.Devices.I2c/I2c.cs
+++ b/GHIElectronics.TinyCLR.Devices.I2c/I2c.cs
@@ -274,8 +274,21 @@ namespace GHIElectronics.TinyCLR.Devices.I2c {
             private void WaitForScl() {
                 var i = 0;
 
-                while (!this.ReadScl() && i++ < 100)
-                    Thread.Sleep(1);
+                // We limit 2KHz on all device
+                const int delay = (1000000 / 2000) * 10; // in ticks
+
+                while (i++ < 100) {
+                    var currentTicks = DateTime.Now.Ticks;
+
+                    while (DateTime.Now.Ticks - currentTicks < delay / 2) ;
+
+                    var state = this.ReadScl();
+
+                    while (DateTime.Now.Ticks - currentTicks < delay) ;
+
+                    if (state)
+                        break;
+                }
 
                 if (i >= 100)
                     throw new I2cClockStretchTimeoutException();


### PR DESCRIPTION
Make clocks are closer as much as we can. Some fast devices, there is no limited so some clocks are very short, and next clock is longer because busy to execute some commands. That causes transaction failed on G400 and UC5550 sometime but it is never happened on slower devices.