### PR TITLE
Fixes for float, double, and DateTime

### DIFF
--- a/GHIElectronics.TinyCLR.Data.Json/JObject.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Reflection;
 using System.Text;
@@ -48,8 +48,17 @@ namespace GHIElectronics.TinyCLR.Data.Json
 					if (m.ReturnType.IsArray)
 						result._members.Add(name.ToLower(), new JProperty(name, JArray.Serialize(m.ReturnType, methodResult)));
 					else
-						result._members.Add(name.ToLower(), new JProperty(name, JObject.Serialize(m.ReturnType, methodResult)));
-				}
+                    {
+                        if (m.ReturnType.IsValueType || m.ReturnType == typeof(string))
+                        {
+                            result._members.Add(name.ToLower(), new JProperty(name, JValue.Serialize(m.ReturnType, methodResult)));
+                        }
+                        else
+                        {
+                            result._members.Add(name.ToLower(), new JProperty(name, JObject.Serialize(m.ReturnType, methodResult)));
+                        }
+                    }
+                }
 			}
 
 			var fields = type.GetFields();

--- a/GHIElectronics.TinyCLR.Data.Json/JValue.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JValue.cs
@@ -1,81 +1,81 @@
-﻿using System;
+using System;
 
 namespace GHIElectronics.TinyCLR.Data.Json
 {
-	public class JValue : JToken
-	{
-		public JValue()
-		{
-		}
+    public class JValue : JToken
+    {
+        public JValue()
+        {
+        }
 
-		public JValue(object value)
-		{
-			this.Value = value;
-		}
+        public JValue(object value)
+        {
+            this.Value = value;
+        }
 
-		public object Value { get; set; }
+        public object Value { get; set; }
 
-		public static JValue Serialize(Type type, object oValue)
-		{
-			return new JValue()
-			{
-				Value = oValue
-			};
-		}
+        public static JValue Serialize(Type type, object oValue)
+        {
+            return new JValue()
+            {
+                Value = oValue
+            };
+        }
 
-		public override string ToString()
-		{
-			EnterSerialization();
-			try
-			{
-				if (Value == null)
-					return "null";
+        public override string ToString()
+        {
+            EnterSerialization();
+            try
+            {
+                if (Value == null)
+                    return "null";
 
-				var type = this.Value.GetType();
-				if (type == typeof(string) || type == typeof(char))
-					return "\"" + this.Value.ToString() + "\"";
-				else if (type == typeof(DateTime))
-					return "\"" + DateTimeExtensions.ToIso8601(((DateTime)this.Value)) + "\"";
-				else
-					return this.Value.ToString();
-			}
-			finally
-			{
-				ExitSerialization();
-			}
-		}
+                var type = this.Value.GetType();
+                if (type == typeof(string) || type == typeof(char))
+                    return "\"" + this.Value.ToString() + "\"";
+                else if (type == typeof(DateTime))
+                    return "\"" + DateTimeExtensions.ToIso8601(((DateTime)this.Value)) + "\"";
+                else
+                    return this.Value.ToString();
+            }
+            finally
+            {
+                ExitSerialization();
+            }
+        }
 
-		public override int GetBsonSize()
-		{
-			if (this.Value == null)
-				return 0;
+        public override int GetBsonSize()
+        {
+            if (this.Value == null)
+                return 0;
 
-			var type = this.Value.GetType();
-			if (type == typeof(double))
-				return 8;
-			else if (type == typeof(string))
-				return ((string)this.Value).Length + 1;  // preamble, strlen, nul
-			if (type == typeof(char))
-				return 1 + 1;  // strlen==1, nul
-			else if (type == typeof(Int32) || type == typeof(UInt32))
-				return 4;
-			else if (type == typeof(Int64) || type == typeof(UInt64))
-				return 8;
-			else if (type == typeof(DateTime))
-				return 8;
-			else if (type == typeof(bool))
-				return 1;
-			else
-				throw new Exception("Unsupported type");
-		}
+            var type = this.Value.GetType();
+            if (type == typeof(double))
+                return 8;
+            else if (type == typeof(string))
+                return ((string)this.Value).Length + 1;  // preamble, strlen, nul
+            if (type == typeof(char))
+                return 1 + 1;  // strlen==1, nul
+            else if (type == typeof(Int32) || type == typeof(UInt32))
+                return 4;
+            else if (type == typeof(Int64) || type == typeof(UInt64) || type == typeof(float) || type == typeof(double))
+                return 8;
+            else if (type == typeof(DateTime))
+                return 8;
+            else if (type == typeof(bool))
+                return 1;
+            else
+                throw new Exception("Unsupported type");
+        }
 
-		public override int GetBsonSize(string ename)
-		{
-			return 1 + ename.Length + 1 + this.GetBsonSize();
-		}
+        public override int GetBsonSize(string ename)
+        {
+            return 1 + ename.Length + 1 + this.GetBsonSize();
+        }
 
-		public override void ToBson(byte[] buffer, ref int offset)
-		{
+        public override void ToBson(byte[] buffer, ref int offset)
+        {
             if (buffer != null)
             {
                 if (this.Value != null)
@@ -85,7 +85,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
             {
                 offset += this.GetBsonSize();
             }
-		}
+        }
 
         public override BsonTypes GetBsonType()
         {
@@ -93,7 +93,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
                 return BsonTypes.BsonNull;
 
             var type = this.Value.GetType();
-            if (type == typeof(double))
+            if (type == typeof(double) || type == typeof(float))
                 return BsonTypes.BsonDouble;
             else if (type == typeof(string))
                 return BsonTypes.BsonString;

--- a/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
@@ -112,7 +112,11 @@ namespace GHIElectronics.TinyCLR.Data.Json
                         {
                             if (field != null)
                             {
-                                if (itemType != typeof(DateTime))
+                                if (itemType == typeof(float))
+                                {
+                                    field.SetValue(instance, (float)((double)((JValue)prop.Value).Value));
+                                }
+                                else if (itemType != typeof(DateTime))
                                 {
                                     field.SetValue(instance, ((JValue)prop.Value).Value);
                                 }
@@ -193,7 +197,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
                 var list = new ArrayList();
 
                 Array array;
-                if (elemType!=null)
+                if (elemType != null)
                     array = Array.CreateInstance(type.GetElementType(), jarray.Length);
                 else
                     array = (Array)factory(path, null, jarray.Length);
@@ -287,7 +291,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
                         throw new Exception("unexpected top-level object type in bson");
                 }
             }
-            if (buffer[offset++]!=0)
+            if (buffer[offset++] != 0)
                 throw new Exception("bad format - missing trailing null on bson document");
             return PopulateObject(dserResult, resultType, "/", factory);
         }

--- a/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
@@ -141,7 +141,10 @@ namespace GHIElectronics.TinyCLR.Data.Json
                             }
                             else
                             {
-                                if (itemType != typeof(DateTime))
+                                if (itemType == typeof(float)) {
+                                    method.Invoke(instance, new object[] { (float)((double)((JValue)prop.Value).Value) });
+                                }
+                                else if (itemType != typeof(DateTime))
                                 {
                                     method.Invoke(instance, new object[] { ((JValue)prop.Value).Value });
                                 }

--- a/GHIElectronics.TinyCLR.Data.Json/SerializationUtilities.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/SerializationUtilities.cs
@@ -1,13 +1,13 @@
-﻿using System;
+using System;
 using System.Text;
 
 namespace GHIElectronics.TinyCLR.Data.Json
 {
-	public static class SerializationUtilities
-	{
-		public static void Marshall(byte[] buffer, ref int offset, object arg)
-		{
-			var type = arg.GetType();
+    public static class SerializationUtilities
+    {
+        public static void Marshall(byte[] buffer, ref int offset, object arg)
+        {
+            var type = arg.GetType();
             if (type == typeof(byte))
             {
                 buffer[offset++] = (byte)arg;
@@ -79,67 +79,89 @@ namespace GHIElectronics.TinyCLR.Data.Json
                 offset += length;
                 buffer[offset++] = 0;
             }
+            else if (type == typeof(float))
+            {
+                var bytes = BitConverter.GetBytes((double)((float)arg));
+                foreach (var b in bytes)
+                {
+                    buffer[offset++] = b;
+                }
+            }
+            else if (type == typeof(double))
+            {
+                var bytes = BitConverter.GetBytes((double)arg);
+                foreach (var b in bytes)
+                {
+                    buffer[offset++] = b;
+                }
+            }
             else
                 throw new Exception("unsupported type for Marshall");
-		}
+        }
 
-		public static object Unmarshall(byte[] buffer, ref int offset, TypeCode tc)
-		{
-			object result = null;
-			switch (tc)
-			{
-				case TypeCode.Empty: // secret code for the argument typecode array
-					var argCount = (int)buffer[offset++];
-					var tcArray = new TypeCode[argCount];
-					for (var i = 0; i < argCount; ++i)
-					{
-						tcArray[i] = (TypeCode)buffer[offset++];
-					}
-					result = tcArray;
-					break;
-				case TypeCode.Byte:
-					result = buffer[offset++];
-					break;
-				case TypeCode.Int16:
-					result = (Int16)(buffer[offset] | buffer[offset + 1] << 8);
-					offset += 2;
-					break;
-				case TypeCode.UInt16:
-					result = (UInt16)(buffer[offset] | buffer[offset + 1] << 8);
-					offset += 2;
-					break;
-				case TypeCode.Int32:
-					result = (Int32)(buffer[offset] | buffer[offset + 1] << 8 | buffer[offset + 2] << 16 | buffer[offset + 3] << 24);
-					offset += 4;
-					break;
-				case TypeCode.UInt32:
-					result = (UInt32)(buffer[offset] | buffer[offset + 1] << 8 | buffer[offset + 2] << 16 | buffer[offset + 3] << 24);
-					offset += 4;
-					break;
-				case TypeCode.Int64:
-					result = (Int64)(((UInt64)buffer[offset]) | ((UInt64)buffer[offset + 1]) << 8 | ((UInt64)buffer[offset + 2]) << 16 | ((UInt64)buffer[offset + 3]) << 24 |
-									 ((UInt64)buffer[offset + 4]) << 32 | ((UInt64)buffer[offset + 5]) << 40 | ((UInt64)buffer[offset + 6]) << 48 | ((UInt64)buffer[offset + 7]) << 56);
-					offset += 8;
-					break;
-				case TypeCode.UInt64:
-					result = (UInt64)(((UInt64)buffer[offset]) | ((UInt64)buffer[offset + 1]) << 8 | ((UInt64)buffer[offset + 2]) << 16 | ((UInt64)buffer[offset + 3]) << 24 |
-									 ((UInt64)buffer[offset + 4]) << 32 | ((UInt64)buffer[offset + 5]) << 40 | ((UInt64)buffer[offset + 6]) << 48 | ((UInt64)buffer[offset + 7]) << 56);
-					offset += 8;
-					break;
-				case TypeCode.DateTime:
-					result = new DateTime((long)Unmarshall(buffer, ref offset, TypeCode.Int64));
-					break;
-				case TypeCode.String:
+        public static object Unmarshall(byte[] buffer, ref int offset, TypeCode tc)
+        {
+            object result = null;
+            switch (tc)
+            {
+                case TypeCode.Empty: // secret code for the argument typecode array
+                    var argCount = (int)buffer[offset++];
+                    var tcArray = new TypeCode[argCount];
+                    for (var i = 0; i < argCount; ++i)
+                    {
+                        tcArray[i] = (TypeCode)buffer[offset++];
+                    }
+                    result = tcArray;
+                    break;
+                case TypeCode.Byte:
+                    result = buffer[offset++];
+                    break;
+                case TypeCode.Int16:
+                    result = (Int16)(buffer[offset] | buffer[offset + 1] << 8);
+                    offset += 2;
+                    break;
+                case TypeCode.UInt16:
+                    result = (UInt16)(buffer[offset] | buffer[offset + 1] << 8);
+                    offset += 2;
+                    break;
+                case TypeCode.Int32:
+                    result = (Int32)(buffer[offset] | buffer[offset + 1] << 8 | buffer[offset + 2] << 16 | buffer[offset + 3] << 24);
+                    offset += 4;
+                    break;
+                case TypeCode.UInt32:
+                    result = (UInt32)(buffer[offset] | buffer[offset + 1] << 8 | buffer[offset + 2] << 16 | buffer[offset + 3] << 24);
+                    offset += 4;
+                    break;
+                case TypeCode.Int64:
+                    result = (Int64)(((UInt64)buffer[offset]) | ((UInt64)buffer[offset + 1]) << 8 | ((UInt64)buffer[offset + 2]) << 16 | ((UInt64)buffer[offset + 3]) << 24 |
+                                     ((UInt64)buffer[offset + 4]) << 32 | ((UInt64)buffer[offset + 5]) << 40 | ((UInt64)buffer[offset + 6]) << 48 | ((UInt64)buffer[offset + 7]) << 56);
+                    offset += 8;
+                    break;
+                case TypeCode.UInt64:
+                    result = (UInt64)(((UInt64)buffer[offset]) | ((UInt64)buffer[offset + 1]) << 8 | ((UInt64)buffer[offset + 2]) << 16 | ((UInt64)buffer[offset + 3]) << 24 |
+                                     ((UInt64)buffer[offset + 4]) << 32 | ((UInt64)buffer[offset + 5]) << 40 | ((UInt64)buffer[offset + 6]) << 48 | ((UInt64)buffer[offset + 7]) << 56);
+                    offset += 8;
+                    break;
+                case TypeCode.DateTime:
+                    result = new DateTime((long)Unmarshall(buffer, ref offset, TypeCode.Int64));
+                    break;
+                case TypeCode.String:
                     var idxNul = JToken.FindNul(buffer, offset);
                     if (idxNul == -1)
                         throw new Exception("Missing ename terminator");
                     result = JToken.ConvertToString(buffer, offset, idxNul - offset);
                     offset = idxNul + 1;
-					break;
-				default:
-					throw new Exception("Unsupported type");
-			}
-			return result;
-		}
-	}
+                    break;
+                case TypeCode.Double:
+                    var i64 = (Int64)(((UInt64)buffer[offset]) | ((UInt64)buffer[offset + 1]) << 8 | ((UInt64)buffer[offset + 2]) << 16 | ((UInt64)buffer[offset + 3]) << 24 |
+                                     ((UInt64)buffer[offset + 4]) << 32 | ((UInt64)buffer[offset + 5]) << 40 | ((UInt64)buffer[offset + 6]) << 48 | ((UInt64)buffer[offset + 7]) << 56);
+                    result = BitConverter.Int64BitsToDouble(i64);
+                    offset += 8;
+                    break;
+                default:
+                    throw new Exception("Unsupported type");
+            }
+            return result;
+        }
+    }
 }

--- a/GHIElectronics.TinyCLR.Data.Json/TimeExtensions.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/TimeExtensions.cs
@@ -115,7 +115,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
 			if (utc)
 			{
 				// Convert the Kind to DateTimeKind.Utc if string Z present
-				dt = new DateTime(0, DateTimeKind.Utc).AddTicks(dt.Ticks);
+				dt = new DateTime(dt.Ticks, DateTimeKind.Utc);
 			}
 
 			return dt;


### PR DESCRIPTION
This commit fixes issue #459

Float and double were not supported as types. Added support for serialization and deserialization of float and double. 

DateTime values near the min and max values were throwing exceptions. Made a minor tweak there, but it still needs a lot more testing around timezone correctness.

This is a remarkably messy set of diffs, as it looks like a lot of whitespace changed too.