### PR TITLE
Make checkboxes consistent with XAML API

### DIFF
--- a/GHIElectronics.TinyCLR.UI/Controls/CheckBox.cs
+++ b/GHIElectronics.TinyCLR.UI/Controls/CheckBox.cs
@@ -10,6 +10,8 @@ using GHIElectronics.TinyCLR.UI.Media.Imaging;
 namespace GHIElectronics.TinyCLR.UI.Controls {
     public class CheckBox : ContentControl {
         public event RoutedEventHandler Click;
+        public event RoutedEventHandler Checked;
+        public event RoutedEventHandler Unchecked;
 
         private BitmapImage bitmapImageCheckboxOn;
         private BitmapImage bitmapImageCheckboxOff;
@@ -19,7 +21,7 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
         public string Name { get; set; } = string.Empty;
         public ushort Alpha { get; set; } = 0xC8;
         public ushort RadiusBorder { get; set; } = 5;
-        
+
 
         private void InitResource() {
             this.bitmapImageCheckboxOn = BitmapImage.FromGraphics(Graphics.FromImage(Resources.GetBitmap(Resources.BitmapResources.CheckBox_On)));
@@ -51,7 +53,16 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
 
             e.Handled = args.Handled;
 
-            this.Checked = !this.Checked;
+            this.IsChecked = !this.IsChecked;
+
+            evt = new RoutedEvent(this.isChecked ? "CheckedEvent" : "UncheckedEvent", RoutingStrategy.Bubble, typeof(RoutedEventHandler));
+            args = new RoutedEventArgs(evt, this);
+            if (this.isChecked) {
+                this.Checked?.Invoke(this, args);
+            }
+            else {
+                this.Unchecked?.Invoke(this, args);
+            }
 
             if (this.Parent != null)
                 this.Invalidate();
@@ -70,8 +81,8 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
                 this.Invalidate();
         }
 
-       
-        public bool Checked {
+
+        public bool IsChecked {
             get => this.isChecked;
             set {
                 if (this.isChecked != value) {


### PR DESCRIPTION
Checkboxes need a checked and unchecked event so that you can do dynamic UI (ui that enables or disables when you check the box),

Also, the naming was inconsistent with XAML, where IsChecked is the property and Checked and Unchecked are events.  This change aligns with the XAML api which will reduce cognitive load for devs moving back and forth between the two.

This resolves issue #482 