### PR TITLE
Text in texbox is misaligned

### DIFF
--- a/GHIElectronics.TinyCLR.UI/Controls/TextBox.cs
+++ b/GHIElectronics.TinyCLR.UI/Controls/TextBox.cs
@@ -53,7 +53,8 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
 
             var txt = this.text;
             var diff = this._renderWidth - this.width;
-            var y = this._font.Height / 2;
+            // Place the centerline of the font at the center of the textbox
+            var y = (this.ActualHeight - this._font.Height) / 2;
 
             if (diff > 0) {
                 dc.DrawText(ref txt, this._font, b.Color, 0, y, this._renderWidth, this._font.Height, this.TextAlign, TextTrimming.CharacterEllipsis);


### PR DESCRIPTION
The text in TextBox controls was misaligned and only half visible.  This change (suggested by Dat) fixes that by vertically centering the text within the textbox rectangle.