### PR TITLE
Ignore touch events when IsEnabled==false

### DIFF
--- a/GHIElectronics.TinyCLR.UI/Controls/Button.cs
+++ b/GHIElectronics.TinyCLR.UI/Controls/Button.cs
@@ -26,6 +26,10 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
         }
 
         protected override void OnTouchUp(TouchEventArgs e) {
+            if (!this.IsEnabled) {
+                return;
+            }
+
             var evt = new RoutedEvent("TouchUpEvent", RoutingStrategy.Bubble, typeof(RoutedEventHandler));
             var args = new RoutedEventArgs(evt, this);
 
@@ -40,6 +44,9 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
         }
 
         protected override void OnTouchDown(TouchEventArgs e) {
+            if (!this.IsEnabled) {
+                return;
+            }
 
             var evt = new RoutedEvent("TouchDownEvent", RoutingStrategy.Bubble, typeof(RoutedEventHandler));
             var args = new RoutedEventArgs(evt, this);

--- a/GHIElectronics.TinyCLR.UI/Controls/CheckBox.cs
+++ b/GHIElectronics.TinyCLR.UI/Controls/CheckBox.cs
@@ -44,6 +44,10 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
         }
 
         protected override void OnTouchUp(TouchEventArgs e) {
+            if (!this.IsEnabled) {
+                return;
+            }
+
             var evt = new RoutedEvent("TouchUpEvent", RoutingStrategy.Bubble, typeof(RoutedEventHandler));
             var args = new RoutedEventArgs(evt, this);
 
@@ -58,6 +62,9 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
         }
 
         protected override void OnTouchDown(TouchEventArgs e) {
+            if (!this.IsEnabled) {
+                return;
+            }
 
             var evt = new RoutedEvent("TouchDownEvent", RoutingStrategy.Bubble, typeof(RoutedEventHandler));
             var args = new RoutedEventArgs(evt, this);

--- a/GHIElectronics.TinyCLR.UI/Controls/ListBoxItem.cs
+++ b/GHIElectronics.TinyCLR.UI/Controls/ListBoxItem.cs
@@ -23,6 +23,10 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
         }
 
         protected override void OnTouchUp(TouchEventArgs e) {
+            if (!this.IsEnabled) {
+                return;
+            }
+
             if (this.IsSelectable) {
                 this._listBox.SelectedItem = this;
             }

--- a/GHIElectronics.TinyCLR.UI/Controls/RadioButton.cs
+++ b/GHIElectronics.TinyCLR.UI/Controls/RadioButton.cs
@@ -119,6 +119,10 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
         }
 
         protected override void OnTouchUp(TouchEventArgs e) {
+            if (!this.IsEnabled) {
+                return;
+            }
+
             var evt = new RoutedEvent("TouchUpEvent", RoutingStrategy.Bubble, typeof(RoutedEventHandler));
             var args = new RoutedEventArgs(evt, this);
 
@@ -133,6 +137,9 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
         }
 
         protected override void OnTouchDown(TouchEventArgs e) {
+            if (!this.IsEnabled) {
+                return;
+            }
 
             var evt = new RoutedEvent("TouchDownEvent", RoutingStrategy.Bubble, typeof(RoutedEventHandler));
             var args = new RoutedEventArgs(evt, this);

--- a/GHIElectronics.TinyCLR.UI/Controls/TextBox.cs
+++ b/GHIElectronics.TinyCLR.UI/Controls/TextBox.cs
@@ -36,6 +36,10 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
         internal bool ForOnScreenKeyboard { get; set; }
 
         protected override void OnTouchUp(TouchEventArgs e) {
+            if (!this.IsEnabled) {
+                return;
+            }
+
             if (!this.ForOnScreenKeyboard)
                 Application.Current.ShowOnScreenKeyboardFor(this);
         }


### PR DESCRIPTION
Controls should not change state or generate other events when IsEnabled is false. The control should be visible but inert.

This implementation follows the behavior described here : https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.control.isenabled

Resolves issue #485 