### PR TITLE
Fix json serialization of boolean values

### DIFF
--- a/GHIElectronics.TinyCLR.Data.Json/JValue.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JValue.cs
@@ -36,6 +36,8 @@ namespace GHIElectronics.TinyCLR.Data.Json
                     return "\"" + this.Value.ToString() + "\"";
                 else if (type == typeof(DateTime))
                     return "\"" + DateTimeExtensions.ToIso8601(((DateTime)this.Value)) + "\"";
+                else if (type == typeof(bool))
+                    return this.Value.ToString().ToLower();
                 else
                     return this.Value.ToString();
             }


### PR DESCRIPTION
The JValue class was serializing booleans as 'True' and 'False' when they should be written out as 'true' and 'false'.

Changed the serialization of booleans to output the correct case. The spec for json is very particular on this point. Booleans must be lowercase.

This is NOT a breaking change for existing programs. The deserializer will accept either upper or lower case, but now it will emit the correct case.