### PR TITLE
Don't throw for missing members

### DIFF
--- a/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
@@ -89,6 +89,9 @@ namespace GHIElectronics.TinyCLR.Data.Json
                     else
                     {
                         method = type.GetMethod("get_" + prop.Name);
+                        if (method == null) {
+                            continue;
+                        }
                         itemType = method.ReturnType;
                         method = type.GetMethod("set_" + prop.Name);
                     }


### PR DESCRIPTION
If a member appears in json, but does not exist on the class you are deserializing, then the function would throw.

With this change, if you have json members and there's no matching member in the strongly type class you are deserializing to, then the extra member in json will be ignored.