### PR TITLE
Add a Contains() function to JObject

### DIFF
--- a/GHIElectronics.TinyCLR.Data.Json/JObject.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JObject.cs
@@ -20,7 +20,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
 			}
 		}
 
-        public bool Contains(string name) => this._members.Contains(name);
+        public bool Contains(string name) => this._members.Contains(name.ToLower());
 
         public ICollection Members
 		{

--- a/GHIElectronics.TinyCLR.Data.Json/JObject.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JObject.cs
@@ -20,7 +20,9 @@ namespace GHIElectronics.TinyCLR.Data.Json
 			}
 		}
 
-		public ICollection Members
+        public bool Contains(string name) => this._members.Contains(name);
+
+        public ICollection Members
 		{
 			get { return _members.Values; }
 		}


### PR DESCRIPTION
JObject is a collection of named children, so it should have a Contains member.  This makes it much easier to probe for a value before trying to retrieve it (and possibly throwing an exception).