### PR TITLE
Get bytes array from an array with pattern

### DIFF
--- a/mscorlib/BitConverter.cs
+++ b/mscorlib/BitConverter.cs
@@ -102,6 +102,14 @@ namespace System {
         extern public static byte[] GetBytes(ushort value);
 
         /// <summary>
+        /// Organize an array with order from a pattern table
+        /// <param name="buffer">The source array.</param>
+        /// <param name="patternTable">The pattern table</param>
+        /// </summary>
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        extern public static byte[] GetBytes(byte[] buffer, byte[] patternTable);
+
+        /// <summary>
         /// Converts the specified 64-bit signed integer to a double-precision floating point number.
         /// </summary>
         /// <param name="value">The number to convert.</param>


### PR DESCRIPTION
TinyCLR doesn't have LookupTable, but dotnet C# has LookupTable class which is different what we wanted.

We have GetBytes(....), so I added GetBytes(byte[] buffer, byte[] patternTable) in BitConverter class.