### PR TITLE
Reassignment of values should not throw

### DIFF
--- a/GHIElectronics.TinyCLR.Data.Json/JObject.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JObject.cs
@@ -16,9 +16,9 @@ namespace GHIElectronics.TinyCLR.Data.Json
 			{
 				if (name.ToLower() != value.Name.ToLower())
 					throw new ArgumentException("index value must match property name");
-				_members.Add(value.Name.ToLower(), value);
-			}
-		}
+                _members[value.Name.ToLower()] = value;
+            }
+        }
 
         public bool Contains(string name) => this._members.Contains(name.ToLower());
 
@@ -29,7 +29,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
 
 		public void Add(string name, JToken value)
 		{
-			_members.Add(name.ToLower(), new JProperty(name, value));
+			_members[name.ToLower()] = new JProperty(name, value);
 		}
 
 		public static JObject Serialize(Type type, object oSource)


### PR DESCRIPTION
Assignment of properties within an object was using .Add() on the HashTable, which will throw if the value already exists.

This makes it hard to read a json blob and then change values before writing it back out (e.g., in the scenario of using json/bson for config).

This change uses subscript assignment instead, which will not throw if the value exists already. This version will just overwrite the existing value. If you want to ensure that you are not overwrtiting a value, use the Contains() test first.