### PR TITLE
Support compact formatting

### DIFF
--- a/GHIElectronics.TinyCLR.Data.Json/GHIElectronics.TinyCLR.Data.Json.csproj
+++ b/GHIElectronics.TinyCLR.Data.Json/GHIElectronics.TinyCLR.Data.Json.csproj
@@ -39,6 +39,7 @@
     <Compile Include="JObject.cs" />
     <Compile Include="JProperty.cs" />
     <Compile Include="JsonConverter.cs" />
+    <Compile Include="JsonSerializationOptions.cs" />
     <Compile Include="JToken.cs" />
     <Compile Include="JValue.cs" />
     <Compile Include="SerializationUtilities.cs" />

--- a/GHIElectronics.TinyCLR.Data.Json/JObject.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JObject.cs
@@ -106,23 +106,35 @@ namespace GHIElectronics.TinyCLR.Data.Json
 		}
 
 		public override string ToString()
+        {
+            return this.ToString(null);
+        }
+
+        public override string ToString(JsonSerializationOptions options)
 		{
-			EnterSerialization();
+			EnterSerialization(options);
 			try
 			{
 				StringBuilder sb = new StringBuilder();
 
-				sb.AppendLine(Indent(true) + "{");
-				bool first = true;
+                sb.Append(Indent(true) + "{");
+                if (JsonConverter.SerializationContext.options.Indented)
+                    sb.AppendLine();
+                bool first = true;
 				foreach (var member in _members.Values)
 				{
 					if (!first)
-						sb.AppendLine(",");
+                    {
+                        sb.Append(",");
+                        if (JsonConverter.SerializationContext.options.Indented)
+                            sb.AppendLine();
+                    }
 					first = false;
-					sb.Append(Indent() + ((JProperty)member).ToString());
+					sb.Append(Indent() + ((JProperty)member).ToString(options));
 				}
-				sb.AppendLine();
-				Outdent();
+                if (JsonConverter.SerializationContext.options.Indented)
+                    sb.AppendLine();
+                Outdent();
 				sb.Append(Indent() + "}");
 				return sb.ToString();
 			}

--- a/GHIElectronics.TinyCLR.Data.Json/JProperty.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JProperty.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 
 namespace GHIElectronics.TinyCLR.Data.Json
@@ -19,15 +19,27 @@ namespace GHIElectronics.TinyCLR.Data.Json
 		public JToken Value { get; set; }
 
 		public override string ToString()
+        {
+            return this.ToString(null);
+        }
+
+        public override string ToString(JsonSerializationOptions options)
 		{
-			EnterSerialization();
+			EnterSerialization(options);
 			try
 			{
 				StringBuilder sb = new StringBuilder();
 				sb.Append('"');
 				sb.Append(this.Name);
-				sb.Append("\" : ");
-				sb.Append(this.Value.ToString());
+                if (JsonConverter.SerializationContext.options.Indented)
+                {
+                    sb.Append("\" : ");
+                }
+                else
+                {
+                    sb.Append("\":");
+                }
+                sb.Append(this.Value.ToString(options));
 				return sb.ToString();
 			}
 			finally

--- a/GHIElectronics.TinyCLR.Data.Json/JToken.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JToken.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using System.Threading;
 
@@ -8,14 +8,19 @@ namespace GHIElectronics.TinyCLR.Data.Json
 	{
 		private bool _fOwnsContext;
 
-		protected void EnterSerialization()
+		protected void EnterSerialization(JsonSerializationOptions options = null)
 		{
+            if (options == null)
+            {
+                options = new JsonSerializationOptions();
+            }
+
 			lock (JsonConverter.SyncObj)
 			{
 				if (JsonConverter.SerializationContext == null)
 				{
-					JsonConverter.SerializationContext = new JsonConverter.SerializationCtx();
-					JsonConverter.SerializationContext.Indent = 0;
+					JsonConverter.SerializationContext = new JsonConverter.SerializationCtx(options);
+					JsonConverter.SerializationContext.IndentLevel = 0;
 					Monitor.Enter(JsonConverter.SerializationContext);
 					_fOwnsContext = true;
 				}
@@ -38,21 +43,26 @@ namespace GHIElectronics.TinyCLR.Data.Json
 
 		protected string Indent(bool incrementAfter = false)
 		{
+            if (!JsonConverter.SerializationContext.options.Indented)
+            {
+                return string.Empty;
+            }
+
 			StringBuilder sb = new StringBuilder();
 			string indent = "  ";
 			if (JsonConverter.SerializationContext != null)
 			{
-				for (int i = 0; i < JsonConverter.SerializationContext.Indent; ++i)
+				for (int i = 0; i < JsonConverter.SerializationContext.IndentLevel; ++i)
 					sb.Append(indent);
 				if (incrementAfter)
-					++JsonConverter.SerializationContext.Indent;
+					++JsonConverter.SerializationContext.IndentLevel;
 			}
 			return sb.ToString();
 		}
 
 		protected void Outdent()
 		{
-			--JsonConverter.SerializationContext.Indent;
+			--JsonConverter.SerializationContext.IndentLevel;
 		}
 
 		public byte[] ToBson()
@@ -129,5 +139,6 @@ namespace GHIElectronics.TinyCLR.Data.Json
             return -1;
         }
 
+        public abstract string ToString(JsonSerializationOptions options);
     }
 }

--- a/GHIElectronics.TinyCLR.Data.Json/JValue.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JValue.cs
@@ -25,7 +25,12 @@ namespace GHIElectronics.TinyCLR.Data.Json
 
         public override string ToString()
         {
-            EnterSerialization();
+            return this.ToString(null);
+        }
+
+        public override string ToString(JsonSerializationOptions options)
+        {
+            EnterSerialization(options);
             try
             {
                 if (Value == null)

--- a/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
@@ -28,7 +28,13 @@ namespace GHIElectronics.TinyCLR.Data.Json
 
         public class SerializationCtx
         {
-            public int Indent;
+            public SerializationCtx(JsonSerializationOptions options)
+            {
+                this.options = options;
+            }
+
+            public readonly JsonSerializationOptions options;
+            public int IndentLevel;
         }
 
         public static SerializationCtx SerializationContext = null;

--- a/GHIElectronics.TinyCLR.Data.Json/JsonSerializationOptions.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JsonSerializationOptions.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections;
+using System.Text;
+using System.Threading;
+
+namespace GHIElectronics.TinyCLR.Data.Json
+{
+    public class JsonSerializationOptions
+    {
+        public bool Indented { get; set; } = true;
+    }
+}


### PR DESCRIPTION
Doing ToString() with Indented == false will generate Json with no whitespace.
This is useful for compact representations like JWT.

There's less change here than it appears. Looks like some automated formatting changed whitespace.

Mainly the serialization context var got renamed from Indent to IndentLevel.
And, a JsonSerializationOptions class was created for passing formatting options to ToString()