### PR TITLE
Fix Issue #831 : NetworkStream send failure when retries are needed

### DIFF
--- a/GHIElectronics.TinyCLR.Networking/Sockets/NetworkStream.cs
+++ b/GHIElectronics.TinyCLR.Networking/Sockets/NetworkStream.cs
@@ -414,7 +414,7 @@ namespace System.Net.Sockets
                 }
                 else
                 {
-                    // last send was fully or partially successful - reduce the retries
+                    // last send was fully or partially successful - reset the retries
                     retries = 5;
                 }
             } while (retries != 0 && count > 0);


### PR DESCRIPTION
Socket.Send will sometimes return 0 for transient errors (normally just meaning that the underlying hardware is not ready.  It would be preferable if the firmware blocked in that case, but this fix introduces retries at the networkstream level to ensure that the stream is not broken for transient errors.  The retry duration may be a bit long.

Again, it would be better if the underlying hardware would block for transient buffer issues and return 0 only for hard errors, but this fix at least keeps the stream from failing.  We can pull this out if the underlying firmware changes.
