### PR TITLE
Optimized ArrayList for working with known capacities

### DIFF
--- a/mscorlib/Collections/ArrayList.cs
+++ b/mscorlib/Collections/ArrayList.cs
@@ -5,6 +5,8 @@ namespace System.Collections {
     [Serializable()]
     [DebuggerDisplay("Count = {Count}")]
     public class ArrayList : IList, ICloneable {
+        private static object[] _emptyArray = new object[0];
+
         private object[] _items;
         private int _size;
 
@@ -12,6 +14,26 @@ namespace System.Collections {
         private const int _defaultCapacity = 4;
 
         public ArrayList() => this._items = new object[_defaultCapacity];
+
+        public ArrayList(int capacity) {
+            if (capacity < 0) throw new ArgumentOutOfRangeException();
+            if (capacity == 0) {
+                this._items = _emptyArray;
+                return;
+            }
+            this._items = new object[capacity];
+        }
+
+        public ArrayList(ICollection c) {
+            if (c == null) throw new ArgumentNullException();
+            var count = c.Count;
+            if (count == 0) {
+                this._items = _emptyArray;
+                return;
+            }
+            this._items = new object[count];
+            c.CopyTo(this._items, 0);
+        }
 
         public virtual int Capacity {
             get => this._items.Length; set => SetCapacity(value);
@@ -35,6 +57,8 @@ namespace System.Collections {
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public extern virtual int Add(object value);
+
+        public virtual void AddRange(ICollection c) => this.InsertRange(this._size, c);
 
         public virtual int BinarySearch(object value, IComparer comparer) => Array.BinarySearch(this._items, 0, this._size, value, comparer);
 
@@ -72,6 +96,27 @@ namespace System.Collections {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public extern virtual void Insert(int index, object value);
 
+        public virtual void InsertRange(int index, ICollection c) {
+            if (c == null) throw new ArgumentNullException();
+            if (index < 0 || index > this._size) throw new ArgumentOutOfRangeException();
+            var count = c.Count;
+            if (count > 0) {
+                if (this._items.Length < this._size + count) this.SetCapacity(this._size + count);
+                if (index < this._size) {
+                    Array.Copy(this._items, index, this._items, index + count, this._size - index);
+                }
+
+                if (this == c && index < this._size) {
+                    Array.Copy(this._items, 0, this._items, index, index);
+                    Array.Copy(this._items, index + count, this._items, index + index, this._size - index);
+                }
+                else {
+                    c.CopyTo(this._items, index);
+                }
+                this._size += count;
+            }
+        }
+
         public virtual void Remove(object obj) {
             var index = Array.IndexOf(this._items, obj, 0, this._size);
             if (index >= 0) {
@@ -81,6 +126,22 @@ namespace System.Collections {
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public extern virtual void RemoveAt(int index);
+
+        public virtual void RemoveRange(int index, int count) {
+            if (index < 0) throw new ArgumentOutOfRangeException();
+            if (count < 0) throw new ArgumentOutOfRangeException();
+            if (this._size - index < count) throw new ArgumentException();
+            if (count > 0) {
+                var newSize = this._size - count;
+                if (index < this._size) {
+                    Array.Copy(this._items, index + count, this._items, index, newSize - index);
+                }
+                for (var i = newSize; i < this._size; i++) {
+                    this._items[i] = null;
+                }
+                this._size = newSize;
+            }
+        }
 
         public virtual object[] ToArray() => (object[])ToArray(typeof(object));
 

--- a/mscorlib/Collections/ArrayList.cs
+++ b/mscorlib/Collections/ArrayList.cs
@@ -33,6 +33,7 @@ namespace System.Collections {
             }
             this._items = new object[count];
             c.CopyTo(this._items, 0);
+            this._size = count;
         }
 
         public virtual int Capacity {


### PR DESCRIPTION
Currently ArrayList does not optimally support setting the initial capacity. You need to first create the ArrayList which creates the default 4 element object array, then you call SetCapacity which orphans the original array and replaces it with the new array. The net result is that if you are doing this frequently you are creating excess garbage. 

This change also adds a subset of the Range methods available in the full framework to support optimally adding ranges of data to an ArrayList and minimizing the creation of garbage.