### PR TITLE
Support object polymorphism

### DIFF
--- a/GHIElectronics.TinyCLR.Data.Json/GHIElectronics.TinyCLR.Data.Json.csproj
+++ b/GHIElectronics.TinyCLR.Data.Json/GHIElectronics.TinyCLR.Data.Json.csproj
@@ -40,12 +40,14 @@
     <Compile Include="JProperty.cs" />
     <Compile Include="JsonConverter.cs" />
     <Compile Include="JsonSerializationOptions.cs" />
+    <Compile Include="JsonSerializerSettings.cs" />
     <Compile Include="JToken.cs" />
     <Compile Include="JValue.cs" />
     <Compile Include="SerializationUtilities.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="TimeExtensions.cs" />
+    <Compile Include="TypeNameHandling.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="GHIElectronics.TinyCLR.Data.Json.nuspec" />

--- a/GHIElectronics.TinyCLR.Data.Json/JArray.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JArray.cs
@@ -17,8 +17,13 @@ namespace GHIElectronics.TinyCLR.Data.Json
             _contents = values;
         }
 
-        private JArray(Array source)
+        private JArray(Array source, JsonSerializerSettings settings = null)
         {
+            if (settings == null)
+            {
+                settings = new JsonSerializerSettings();
+            }
+
             _contents = new JToken[source.Length];
             for (int i = 0; i < source.Length; ++i)
             {
@@ -37,11 +42,11 @@ namespace GHIElectronics.TinyCLR.Data.Json
                 {
                     if (fieldType.IsArray)
                     {
-                        _contents[i] = JArray.Serialize(fieldType, value);
+                        _contents[i] = JArray.Serialize(fieldType, value, settings);
                     }
                     else
                     {
-                        _contents[i] = JObject.Serialize(fieldType, value);
+                        _contents[i] = JObject.Serialize(fieldType, value, settings);
                     }
                 }
 
@@ -58,9 +63,14 @@ namespace GHIElectronics.TinyCLR.Data.Json
             get { return _contents; }
         }
 
-        public static JArray Serialize(Type type, object oSource)
+        public static JArray Serialize(Type type, object oSource, JsonSerializerSettings settings = null)
         {
-            return new JArray((Array)oSource);
+            if (settings == null)
+            {
+                settings = new JsonSerializerSettings();
+            }
+
+            return new JArray((Array)oSource, settings);
         }
 
         public JToken this[int i]

--- a/GHIElectronics.TinyCLR.Data.Json/JObject.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JObject.cs
@@ -57,7 +57,8 @@ namespace GHIElectronics.TinyCLR.Data.Json
                         }
                         else
                         {
-                            result._members.Add(name.ToLower(), new JProperty(name, JObject.Serialize(m.ReturnType, methodResult)));
+                            var methodResultType = methodResult.GetType();
+                            result._members.Add(name.ToLower(), new JProperty(name, JObject.Serialize(methodResultType, methodResult)));
                         }
                     }
                 }

--- a/GHIElectronics.TinyCLR.Data.Json/JObject.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JObject.cs
@@ -32,9 +32,14 @@ namespace GHIElectronics.TinyCLR.Data.Json
 			_members[name.ToLower()] = new JProperty(name, value);
 		}
 
-		public static JObject Serialize(Type type, object oSource)
+		public static JObject Serialize(Type type, object oSource, JsonSerializerSettings settings = null)
 		{
-			var result = new JObject();
+            if (settings == null)
+            {
+                settings = new JsonSerializerSettings();
+            }
+
+            var result = new JObject();
 			var methods = type.GetMethods();
 			foreach (var m in methods)
 			{
@@ -48,7 +53,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
 					if (methodResult == null)
 						result._members.Add(name.ToLower(), new JProperty(name, JValue.Serialize(m.ReturnType, null)));
 					if (m.ReturnType.IsArray)
-						result._members.Add(name.ToLower(), new JProperty(name, JArray.Serialize(m.ReturnType, methodResult)));
+						result._members.Add(name.ToLower(), new JProperty(name, JArray.Serialize(m.ReturnType, methodResult, settings)));
 					else
                     {
                         if (m.ReturnType.IsValueType || m.ReturnType == typeof(string))
@@ -58,7 +63,14 @@ namespace GHIElectronics.TinyCLR.Data.Json
                         else
                         {
                             var methodResultType = methodResult.GetType();
-                            result._members.Add(name.ToLower(), new JProperty(name, JObject.Serialize(methodResultType, methodResult)));
+                            var child = JObject.Serialize(methodResultType, methodResult, settings);
+                            if (settings.TypeNameHandling == TypeNameHandling.Objects ||
+                               (settings.TypeNameHandling == TypeNameHandling.Auto && methodResultType != m.ReturnType))
+                            {
+                                child.Add("$type", new JValue(methodResultType.FullName + ", " + methodResultType.Assembly.GetName().Name));
+                            }
+
+                            result._members.Add(name.ToLower(), new JProperty(name, child));
                         }
                     }
                 }
@@ -89,12 +101,12 @@ namespace GHIElectronics.TinyCLR.Data.Json
 							if (f.FieldType.IsArray)
 							{
 								result._members.Add(f.Name.ToLower(),
-									new JProperty(f.Name, JArray.Serialize(f.FieldType, value)));
+									new JProperty(f.Name, JArray.Serialize(f.FieldType, value, settings)));
 							}
 							else
 							{
 								result._members.Add(f.Name.ToLower(),
-									new JProperty(f.Name, JObject.Serialize(f.FieldType, value)));
+									new JProperty(f.Name, JObject.Serialize(f.FieldType, value, settings)));
 							}
 						}
 						break;

--- a/GHIElectronics.TinyCLR.Data.Json/JsonSerializerSettings.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JsonSerializerSettings.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections;
+using System.Text;
+using System.Threading;
+
+namespace GHIElectronics.TinyCLR.Data.Json {
+    public class JsonSerializerSettings
+    {
+        public TypeNameHandling TypeNameHandling { get; set; } = TypeNameHandling.None;
+    }
+}

--- a/GHIElectronics.TinyCLR.Data.Json/TypeNameHandling.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/TypeNameHandling.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections;
+using System.Text;
+using System.Threading;
+
+namespace GHIElectronics.TinyCLR.Data.Json {
+    public enum TypeNameHandling
+    {
+        None = 0,
+        Objects = 1,
+        // Not supported yet...
+        //Arrays = 2,
+        //All = 3,
+        Auto = 4,
+    }
+}


### PR DESCRIPTION
This resolves Issue #796 

Previously, if you tried to serialize an object that had members that were base classes or interfaces, then only the properties defined on the base class would get serialized. Instance-level members would be lost.

With this set of changes, the instance-level properties are serialized.  However, to recover those during de-serialization, you need to either provide an InstanceFactory which will create the correct C# object to be populated, or you have to serialize with TypeNameHandling set to something other than None.

When you set TypeNameHandling to Objects or Auto, then a "$type" member is emitted into the Json. When deserializing, the default instance factory will use this value to try to create the correct type.  You can override this behavior on deserialization by providing an InstanceFactory, and in that factory, you can use your own heuristics for creating instances during deserialization.

TypeNameHandling.None will never emit the $type members.
TypeNameHandling.Objects will always emit $type
TypeNameHandling.Auto will emit the $type only if the instance type being serialized differs from the property type in the parent object.

If you omit both an InstanceFactory AND use TypeNameHandling.None during serialization (which is the default), then deserialization will use the parent property type and any sub-classed members will not be deserialized.
