### PR TITLE
TextBox has no borders #828

### DIFF
--- a/GHIElectronics.TinyCLR.UI/Controls/TextBox.cs
+++ b/GHIElectronics.TinyCLR.UI/Controls/TextBox.cs
@@ -11,7 +11,9 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
 
     public class TextBox : Control {
         private string text = string.Empty;
-        private int width;
+        private Color bordercolor = Colors.Black;
+        private ushort borderthickness = 1, paddingx, paddingy;
+        private int width, height;
 
         public TextBox() => this.Background = new SolidColorBrush(Colors.White);
 
@@ -33,6 +35,34 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
             }
         }
 
+        public Color BorderColor {
+            get => this.bordercolor;
+            set {
+                this.bordercolor = value;
+
+                this.InvalidateMeasure();
+            }
+        }
+
+        public ushort BorderThickness {
+            get => this.borderthickness;
+            set {
+                this.borderthickness = value;
+
+                this.InvalidateMeasure();
+            }
+        }
+
+        public ushort PaddingX {
+            get => this.paddingx;
+            set => this.paddingx = value;
+        }
+
+        public ushort PaddingY {
+            get => this.paddingy;
+            set => this.paddingy = value;
+        }
+
         internal bool ForOnScreenKeyboard { get; set; }
 
         protected override void OnTouchUp(TouchEventArgs e) {
@@ -47,7 +77,13 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
         protected override void MeasureOverride(int availableWidth, int availableHeight, out int desiredWidth, out int desiredHeight) {
             this._font.ComputeExtent(this.text, out desiredWidth, out desiredHeight);
 
-            this.width = desiredWidth;
+            desiredWidth = this._font.MaxWidth + (this.PaddingY * 2) + (this.BorderThickness * 2);
+            desiredHeight = this._font.Height + (this.PaddingY * 2) + (this.BorderThickness * 2);
+        }
+
+        protected override void ArrangeOverride(int arrangeWidth, int arrangeHeight) {
+            this.width = arrangeWidth;
+            this.height = arrangeHeight;
         }
 
         public override void OnRender(DrawingContext dc) {
@@ -56,16 +92,24 @@ namespace GHIElectronics.TinyCLR.UI.Controls {
             base.OnRender(dc);
 
             var txt = this.text;
-            var diff = this._renderWidth - this.width;
+            //var diff = this._renderWidth - this.width;
             // Place the centerline of the font at the center of the textbox
-            var y = (this.ActualHeight - this._font.Height) / 2;
+            //var y = (this.ActualHeight - this._font.Height) / 2;
+            var x = this.BorderThickness + this.PaddingX;
+            var y = this.BorderThickness + this.PaddingY;
+            var w = this.width - (this.BorderThickness * 2) - (this.PaddingX * 2);
 
-            if (diff > 0) {
-                dc.DrawText(ref txt, this._font, b.Color, 0, y, this._renderWidth, this._font.Height, this.TextAlign, TextTrimming.CharacterEllipsis);
+            if (this.BorderThickness > 0) {
+                dc.DrawRectangle(this.Background, new Pen(this.BorderColor, this.BorderThickness), 0, 0, this.width, this.height);
             }
-            else {
-                dc.DrawText(ref txt, this._font, b.Color, diff, y, this._renderWidth + this.width, this._font.Height, this.TextAlign, TextTrimming.CharacterEllipsis);
-            }
+
+            //if (diff > 0) {
+            //    dc.DrawText(ref txt, this._font, b.Color, 0, y, this._renderWidth, this._font.Height, this.TextAlign, TextTrimming.CharacterEllipsis);
+            //}
+            //else {
+            //    dc.DrawText(ref txt, this._font, b.Color, diff, y, this._renderWidth + this.width, this._font.Height, this.TextAlign, TextTrimming.CharacterEllipsis);
+            //}
+            dc.DrawText(ref txt, this._font, b.Color, x, y, w, this._font.Height, this.TextAlign, TextTrimming.CharacterEllipsis);
         }
     }
 }


### PR DESCRIPTION
added border to TextBox and some Properties

- BorderColor
> color of the border, by default black
- BorderThickness
> thickness of the border, by default 1, to hide set it to 0
- PaddingX
> horizontal padding of text within textbox, by default not set
- PaddingY
> vertical padding of text within textbox, by default not set

important: the height will be automatically calculated depending on font height, border thickness and padding

example with border:
```
TextBox text = new TextBox()
{
    Font = font,
    HorizontalAlignment = HorizontalAlignment.Left,
    VerticalAlignment = VerticalAlignment.Bottom,
    BorderColor = Colors.Red,
    Text = "The quick brown fox jumps over the lazy dog",
    Height = 10
};
```
example with no border but with padding:
```
TextBox text = new TextBox()
{
    Font = font,
    HorizontalAlignment = HorizontalAlignment.Left,
    VerticalAlignment = VerticalAlignment.Top,
    PaddingX = 10,
    PaddingY = 20,
    BorderThickness = 0,
    Text = "The quick brown fox jumps over the lazy dog",
    Width = 200
};
```