### PR TITLE
Remove extra GetType() which caused null deref

### DIFF
--- a/mscorlib/Enum.cs
+++ b/mscorlib/Enum.cs
@@ -4,6 +4,6 @@ namespace System {
         public string ToString(string format, IFormatProvider formatProvider) => this.ToString();
         public override string ToString() => this.GetType().GetField("value__").GetValue(this).ToString();
 
-        public static Type GetUnderlyingType(Type enumType) => enumType.GetType().GetField("value__").FieldType;
+        public static Type GetUnderlyingType(Type enumType) => enumType.GetField("value__").FieldType;
     }
 }


### PR DESCRIPTION
The type passed in to GetUnderlyingType() is already the type of the enum.  Calling it again
returns the type of Type, which has no "value__" field, resulting in a null deref of .FieldType.

Removing the extra calls ensures that they are made upon the correct type and the correct
value is returned.