### PR TITLE
Fix ISO 8601 parsing

### DIFF
--- a/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
@@ -288,14 +288,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
                 if (targetType.IsEnum)
                 {
                     // This is broken in TinyCLR
-                    //var baseType = Enum.GetUnderlyingType(targetType);
-
-                    // But this is a substitute
-                    var fields = targetType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                    if (fields == null || fields.Length != 1)
-                        throw new Exception("Failed to get enum underlying type");
-
-                    var baseType = fields[0].FieldType;
+                    var baseType = Enum.GetUnderlyingType(targetType);
 
                     // explicit unboxing, because unboxing with casting fails
                     var source = value.Value;

--- a/GHIElectronics.TinyCLR.Data.Json/TimeExtensions.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/TimeExtensions.cs
@@ -91,7 +91,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
 			string second = (parts.Length > 5) ? parts[5] : "0";
 			string ms = (parts.Length > 6) ? parts[6] : "0";
 
-			DateTime dt = new DateTime(Convert.ToInt32(year), Convert.ToInt32(month), Convert.ToInt32(day), Convert.ToInt32(hour), Convert.ToInt32(minute), Convert.ToInt32(second), Convert.ToInt32(ms));
+			DateTime dt = new DateTime(Convert.ToInt32(year), Convert.ToInt32(month), Convert.ToInt32(day), Convert.ToInt32(hour), Convert.ToInt32(minute), Convert.ToInt32(second), (int)Math.Round(Convert.ToDouble("0." + ms) * 1000.0));
 
 			// If a time offset was specified instead of the UTC marker,
 			// add/subtract in the hours/minutes
@@ -102,21 +102,17 @@ namespace GHIElectronics.TinyCLR.Data.Json
 				string minuteOffset = (parts.Length > 8) ? parts[8] : "";
 				if (date.Contains("+"))
 				{
-					dt = dt.AddHours(Convert.ToDouble(hourOffset));
-					dt = dt.AddMinutes(Convert.ToDouble(minuteOffset));
-				}
-				else
+                    dt = dt.AddHours(-(Convert.ToDouble(hourOffset)));
+                    dt = dt.AddMinutes(-(Convert.ToDouble(minuteOffset)));
+                }
+                else
 				{
-					dt = dt.AddHours(-(Convert.ToDouble(hourOffset)));
-					dt = dt.AddMinutes(-(Convert.ToDouble(minuteOffset)));
-				}
-			}
+                    dt = dt.AddHours(Convert.ToDouble(hourOffset));
+                    dt = dt.AddMinutes(Convert.ToDouble(minuteOffset));
+                }
+            }
 
-			if (utc)
-			{
-				// Convert the Kind to DateTimeKind.Utc if string Z present
-				dt = new DateTime(dt.Ticks, DateTimeKind.Utc);
-			}
+        	dt = new DateTime(dt.Ticks, DateTimeKind.Utc);
 
 			return dt;
 		}


### PR DESCRIPTION
The ISO 8601 parsing did not handle milliseconds correctly at all - that's been fixed and ms are now added
to the base time correctly.

Also, non-Zulu (UTC) times were being recorded as DateTimeKind == Unspecified, which made handling
of time zones difficult or impossible.  Now, the code records all times as UTC, and the caller can use
ToLocalTime() to get the local time according to the time zone set in SystemTime.SetTime(...).

This PR fixes #1005 