### PR TITLE
Fix construction of arrays that are props

### DIFF
--- a/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JsonConverter.cs
@@ -186,10 +186,10 @@ namespace GHIElectronics.TinyCLR.Data.Json
 
                             var jarray = (JArray)prop.Value;
                             var list = new ArrayList();
-                            var array = (Array)factory(path, prop.Value, field.FieldType.GetElementType(), prop.Name, jarray.Length);
+                            var array = (Array)factory(path, prop.Value, itemType.GetElementType(), prop.Name, jarray.Length);
                             if (array == null)
                             {
-                                instance = DefaultInstanceFactory(path, prop.Value, field.FieldType.GetElementType(), prop.Name, jarray.Length);
+                                instance = DefaultInstanceFactory(path, prop.Value, itemType.GetElementType(), prop.Name, jarray.Length);
                             }
 
                             //var array = Array.CreateInstance(field.FieldType.GetElementType(), jarray.Length);


### PR DESCRIPTION
The code was using field.FieldType instead of itemType. 'field' will be null for prop types, so this throws. Use the previously set itemType var which is already normalized for both props and fields.