### PR TITLE
Adding a few 'ease of use' tweaks to the library.

### DIFF
--- a/GHIElectronics.TinyCLR.Devices.Gpio/Gpio.cs
+++ b/GHIElectronics.TinyCLR.Devices.Gpio/Gpio.cs
@@ -118,6 +118,8 @@ namespace GHIElectronics.TinyCLR.Devices.Gpio {
 
         public void Write(GpioPinValue value) => this.Controller.Provider.Write(this.PinNumber, value);
 
+        public void Toggle() => this.Controller.Provider.Write(this.PinNumber, this.Controller.Provider.Read(this.PinNumber) == GpioPinValue.Low ? GpioPinValue.High : GpioPinValue.Low);
+
         public GpioPinEdge ValueChangedEdge {
             get => this.valueChangedEdge;
 

--- a/mscorlib/Diagnostics/Debug.cs
+++ b/mscorlib/Diagnostics/Debug.cs
@@ -10,6 +10,12 @@ namespace System.Diagnostics {
         extern static public void EnableGCMessages(bool enable);
 
         [Conditional("DEBUG")]
+        public static void Write(string message) {
+            foreach (var listener in Debug.Listeners)
+                ((TraceListener)listener).Write(message);
+        }
+
+        [Conditional("DEBUG")]
         public static void WriteLine(string message) {
             foreach (var listener in Debug.Listeners)
                 ((TraceListener)listener).WriteLine(message);

--- a/mscorlib/Threading/Timeout.cs
+++ b/mscorlib/Threading/Timeout.cs
@@ -8,6 +8,7 @@ namespace System.Threading {
     //This class has only static members and does not require serialization.
     public static class Timeout {
         public const int Infinite = -1;
+        public static readonly TimeSpan InfiniteTimeSpan = new TimeSpan(0, 0, 0, 0, -1);
     }
 
 }


### PR DESCRIPTION
Gpio.cs
What: Add Toggle Method.
Why: Reduce boiler plate code when toggling a port

Timeout.cs
What: Add InfiniteTimeSpan.
Why: Allows use of Timer.Change method with Timespan overload

mscorlib/Debug
What: Add Write Method.
Why: There is no current way to write to debug without adding a a carriage return/line feed