### PR TITLE
Fix "key already exists" when using abstracts

### DIFF
--- a/GHIElectronics.TinyCLR.Data.Json/JObject.cs
+++ b/GHIElectronics.TinyCLR.Data.Json/JObject.cs
@@ -43,7 +43,7 @@ namespace GHIElectronics.TinyCLR.Data.Json
 			var methods = type.GetMethods();
 			foreach (var m in methods)
 			{
-				if (!m.IsPublic)
+				if (!m.IsPublic || m.IsAbstract)
 					continue;
 
 				if (m.Name.IndexOf("get_") == 0)


### PR DESCRIPTION
If you use a property that is overridden from an abstract baseclass, you get a "key already exists" exception when trying to serialize the object.
By skipping the abstract fields just like the private ones, this issue is fixed.

This small fix is tested and solves my problem.