### PR TITLE
Bugfix: Some fields were set to null before the object was disposed.

### DIFF
--- a/GHIElectronics.TinyCLR.Networking.Http/System.Net._OutputNetworkStreamWrapper.cs
+++ b/GHIElectronics.TinyCLR.Networking.Http/System.Net._OutputNetworkStreamWrapper.cs
@@ -119,8 +119,6 @@ namespace System.Net
             }
 
             this.m_Stream.Close();
-            this.m_Stream = null;
-            this.m_Socket = null;
         }
 
         /// <summary>


### PR DESCRIPTION
See issue #1222 for more information.
Closes #1222 